### PR TITLE
Updated version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "observable-property-tokio"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 authors = ["Iede Snoek <info@esoxsolutions.nl>"]
 description = "A thread-safe, async-compatible observable property implementation for Rust using Tokio"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-observable-property-tokio = "0.2.0"
+observable-property-tokio = "0.3.0"
 tokio = { version = "1.47.1", features = ["rt", "rt-multi-thread", "macros", "time"] }
 ```
 


### PR DESCRIPTION
This pull request updates the crate version for `observable-property-tokio` to `0.3.0` in preparation for a new release. The most important changes are:

Version bump:

* Updated the `version` field in `Cargo.toml` from `0.2.0` to `0.3.0`, indicating a new release of the crate.

Documentation update:

* Changed the version in the dependency example in `README.md` to `0.3.0` to match the new release.